### PR TITLE
msm8956:Make brightness ramp rates multiples of 60.

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -472,6 +472,10 @@
 
     <!-- Whether or not swipe up gesture's opt-in setting is available on this device -->
     <bool name="config_swipe_up_gesture_setting_available">true</bool>
+  
+    <!-- Fast brightness animation ramp rate in brightness units per second-->
+    <integer translatable="false" name="config_brightness_ramp_rate_fast">180</integer>
+  
+    <!-- Slow brightness animation ramp rate in brightness units per second-->
+    <integer translatable="false" name="config_brightness_ramp_rate_slow">60</integer>
 </resources>
-
-


### PR DESCRIPTION
If ramp rates aren't even multiple of 60 then we're more likely to get
brightness changes that differ each frame, which can show up as a
stuttering in the animation.

Bug: 64514692
Test: made change, took systrace, saw smooth ramping