### PR TITLE
msm8956: Fix high-res direct PCM output

### DIFF
--- a/audio/audio_output_policy.conf
+++ b/audio/audio_output_policy.conf
@@ -52,22 +52,15 @@ outputs {
     bit_width 16
     app_type 69936
   }
-  direct {
-    flags AUDIO_OUTPUT_FLAG_DIRECT
-    formats AUDIO_FORMAT_PCM_16_BIT
-    sampling_rates 48000
-    bit_width 16
-    app_type 69936
-  }
   direct_pcm_16 {
-    flags AUDIO_OUTPUT_FLAG_DIRECT|AUDIO_OUTPUT_FLAG_DIRECT_PCM
+    flags AUDIO_OUTPUT_FLAG_DIRECT
     formats AUDIO_FORMAT_PCM_16_BIT|AUDIO_FORMAT_PCM_24_BIT_PACKED|AUDIO_FORMAT_PCM_8_24_BIT
     sampling_rates 44100|48000|96000|192000
     bit_width 16
     app_type 69936
   }
   direct_pcm_24 {
-    flags AUDIO_OUTPUT_FLAG_DIRECT|AUDIO_OUTPUT_FLAG_DIRECT_PCM
+    flags AUDIO_OUTPUT_FLAG_DIRECT
     formats AUDIO_FORMAT_PCM_24_BIT_PACKED|AUDIO_FORMAT_PCM_8_24_BIT
     sampling_rates 44100|48000|96000|192000
     bit_width 24

--- a/audio/audio_policy_configuration.xml
+++ b/audio/audio_policy_configuration.xml
@@ -73,13 +73,8 @@
                     <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
                              samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
                 </mixPort>
-                <mixPort name="multichannel" role="source"
-                        flags="AUDIO_OUTPUT_FLAG_DIRECT">
-                    <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
-                             samplingRates="44100,48000" channelMasks="dynamic"/>
-                </mixPort>
                 <mixPort name="direct_pcm" role="source"
-                        flags="AUDIO_OUTPUT_FLAG_DIRECT|AUDIO_OUTPUT_FLAG_DIRECT_PCM">
+                        flags="AUDIO_OUTPUT_FLAG_DIRECT">
                     <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
                              samplingRates="8000,11025,12000,16000,22050,24000,32000,44100,48000,64000,88200,96000,176400,192000"
                              channelMasks="AUDIO_CHANNEL_OUT_MONO,AUDIO_CHANNEL_OUT_STEREO,AUDIO_CHANNEL_OUT_2POINT1,AUDIO_CHANNEL_OUT_QUAD,AUDIO_CHANNEL_OUT_PENTA,AUDIO_CHANNEL_OUT_5POINT1,AUDIO_CHANNEL_OUT_6POINT1,AUDIO_CHANNEL_OUT_7POINT1"/>
@@ -255,9 +250,9 @@
                 <route type="mix" sink="Line"
                        sources="primary output,raw,deep_buffer,direct_pcm,compressed_offload,voip_rx"/>
                 <route type="mix" sink="HDMI"
-                       sources="primary output,raw,deep_buffer,multichannel,direct_pcm,compressed_offload"/>
+                       sources="primary output,raw,deep_buffer,direct_pcm,compressed_offload"/>
                 <route type="mix" sink="Proxy"
-                       sources="primary output,raw,deep_buffer,multichannel,direct_pcm,compressed_offload"/>
+                       sources="primary output,raw,deep_buffer,direct_pcm,compressed_offload"/>
                 <route type="mix" sink="FM"
                        sources="primary output"/>
                 <route type="mix" sink="BT SCO All"


### PR DESCRIPTION
```
* Fix 24bit, high sample rates (up to 192KHz) outputs on media players that support this feature.
* Delete multichannel mix port (since we don't use it)
* Cleanup redundant and useless outputs on the output policy

Tested personally on my kenzo.
Credits to ScreaMySkrillEX@xda for finding out the buggy flags.
```

Okay so this is the right cleaned up version of the previous pull request. Please accept it :heart: or just cherry pick my commit, idc