### PR TITLE
Add "vendor." prefix to wcnss-service

### DIFF
--- a/rootdir/etc/init.target.rc
+++ b/rootdir/etc/init.target.rc
@@ -84,7 +84,7 @@ service vendor.thermal-engine /system/vendor/bin/thermal-engine
 on boot
     start vendor.rmt_storage
    
-service wcnss-service /system/bin/wcnss_service
+service vendor.wcnss-service /system/bin/wcnss_service
     class main
     user system
     group system wifi radio


### PR DESCRIPTION
Fixes wcnss_service not starting at boot, preventing Wifi from working on a clean rom